### PR TITLE
Add build_recommends

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,10 @@ Revision history for Perl extension Module::Build.
   - Fixed bug in PodParser to allow numerals in module names
     [Tokuhirom]
 
+  [ENHANCEMENTS]
+
+  - Addition of build_recommends.
+
 0.39_01 - Thu Jul 21 16:48:48 EDT 2011
 
   [BUG FIXES]

--- a/lib/Module/Build/API.pod
+++ b/lib/Module/Build/API.pod
@@ -144,6 +144,26 @@ installed when C<perl Build.PL> is executed, but you've listed in
 L</build_requires> so that they should be available when C<./Build> is
 executed.
 
+=item build_recommends
+
+[version 0.39_02]
+
+This is just like the L</build_requires> argument, except that modules listed
+in this section aren't essential, just a good idea.  We'll just print
+a friendly warning if one of these modules aren't found, but we'll
+continue running.
+
+If a module is recommended but not required, all tests should still
+pass if the module isn't installed.  This may mean that some tests
+may be skipped if recommended dependencies aren't present.
+
+Automated tools like CPAN.pm should inform the user when recommended
+modules aren't installed, and it should offer to install them if it
+wants to be helpful.
+
+See the documentation for L<Module::Build::Authoring/"PREREQUISITES">
+for the details of how requirements can be specified.
+
 =item build_requires
 
 [version 0.07]

--- a/lib/Module/Build/Authoring.pod
+++ b/lib/Module/Build/Authoring.pod
@@ -172,6 +172,14 @@ want to install these items temporarily.  It also helps reduce the
 size of the CPAN dependency graph if everything isn't smooshed into
 C<requires>.
 
+=item build_recommends
+
+Items that are recommended for building and testing this distribution,
+but aren't necessary after installation, and aren't required to
+provide comprehensive testing. Installlation and testing is possible
+without these, but some tests could be skipped as a result of one
+missing.
+
 =item requires
 
 Items that are necessary for basic functioning.

--- a/lib/Module/Build/Base.pm
+++ b/lib/Module/Build/Base.pm
@@ -636,7 +636,7 @@ sub features     {
     if (my $info = $ph->{auto_features}->access($key)) {
       my $disabled;
       for my $type ( @{$self->prereq_action_types} ) {
-        next if $type eq 'description' || $type eq 'recommends' || ! exists $info->{$type};
+        next if $type eq 'description' || $type =~ /^(?:\w+_)?recommends$/ || ! exists $info->{$type};
         my $prereqs = $info->{$type};
         for my $modname ( sort keys %$prereqs ) {
           my $spec = $prereqs->{$modname};
@@ -938,7 +938,7 @@ __PACKAGE__->add_property(
 }
 
 {
-  my @prereq_action_types = qw(requires build_requires conflicts recommends);
+  my @prereq_action_types = qw(requires build_requires build_recommends conflicts recommends);
   foreach my $type (@prereq_action_types) {
     __PACKAGE__->add_property($type => {});
   }
@@ -1910,6 +1910,7 @@ sub create_mymeta {
     # XXX refactor this mapping somewhere
     $mymeta->{prereqs}{runtime}{requires} = $prereqs->{requires};
     $mymeta->{prereqs}{build}{requires} = $prereqs->{build_requires};
+    $mymeta->{prereqs}{build}{recommends} = $prereqs->{build_recommends};
     $mymeta->{prereqs}{runtime}{recommends} = $prereqs->{recommends};
     $mymeta->{prereqs}{runtime}{conflicts} = $prereqs->{conflicts};
     # delete empty entries

--- a/lib/Module/Build/Notes.pm
+++ b/lib/Module/Build/Notes.pm
@@ -228,7 +228,7 @@ sub feature {
 
   require Module::Build;  # XXX should get rid of this
   while (my ($type, $prereqs) = each %info) {
-    next if $type eq 'description' || $type eq 'recommends';
+    next if $type eq 'description' || $type =~ /^(?:\w+_)?recommends$/;
 
     my %p = %$prereqs;  # Ditto here.
     while (my ($modname, $spec) = each %p) {

--- a/t/basic.t
+++ b/t/basic.t
@@ -2,7 +2,7 @@
 
 use strict;
 use lib 't/lib';
-use MBTest tests => 58;
+use MBTest tests => 59;
 
 blib_load('Module::Build');
 
@@ -92,6 +92,20 @@ $dist->chdir_in;
   my $mb = Module::Build->new(
     module_name => $dist->name,
     recommends  => {ModuleBuildNonExistent => 3},
+  );
+  ok $flagged;
+  $dist->clean;
+}
+
+{
+  # Make sure the correct warning message is generated when an
+  # optional build prereq isn't installed
+  my $flagged = 0;
+  local $SIG{__WARN__} = sub { $flagged = 1 if $_[0] =~ /ModuleBuildNonExistent is not installed/};
+
+  my $mb = Module::Build->new(
+    module_name      => $dist->name,
+    build_recommends => {ModuleBuildNonExistent => 3},
   );
   ok $flagged;
   $dist->clean;


### PR DESCRIPTION
There's no good way to specify optional modules for tests, so tests are getting skipped left and right in just about every distro.

This commit adds build_recommends to address that problem.

Documentation updated, tests added, F&lt;Changes> updated.
