### PR TITLE
spelling mistake in API.pod makes link fail

### DIFF
--- a/lib/Module/Build/API.pod
+++ b/lib/Module/Build/API.pod
@@ -1921,7 +1921,7 @@ accessor methods for the following properties:
 If you would like to add other useful metadata, C<Module::Build>
 supports this with the C<meta_add> and C<meta_merge> arguments to
 L</new()>. The authoritative list of supported metadata can be found at
-L<CPAN::META::Spec> but for convenience - here are a few of the more useful ones:
+L<CPAN::Meta::Spec> but for convenience - here are a few of the more useful ones:
 
 =over 4
 


### PR DESCRIPTION
fix link from UpperCase CPAN::META::Spec to CPAN::Meta::Spec
