### PR TITLE
Subclasses of M::B should be added to configure_requires

### DIFF
--- a/lib/Module/Build/Base.pm
+++ b/lib/Module/Build/Base.pm
@@ -1474,20 +1474,21 @@ sub _feature_deps_msg {
 # Automatically detect configure_requires prereqs
 sub auto_config_requires {
   my ($self) = @_;
+  my $builder = ref $self;
   my $p = $self->{properties};
 
-  # add current Module::Build to configure_requires if there
+  # add current Module::Build (or subclass) to configure_requires if there
   # isn't one already specified (but not ourself, so we're not circular)
-  if ( $self->dist_name ne 'Module-Build'
+  if ( $self->module_name ne $builder
     && $self->auto_configure_requires
-    && ! exists $p->{configure_requires}{'Module::Build'}
+    && ! exists $p->{configure_requires}{$builder}
   ) {
-    (my $ver = $VERSION) =~ s/^(\d+\.\d\d).*$/$1/; # last major release only
+    (my $ver = $self->VERSION) =~ s/^(\d+\.\d\d).*$/$1/; # last major release only
     $self->log_warn(<<EOM);
-Module::Build was not found in configure_requires! Adding it now
-automatically as: configure_requires => { 'Module::Build' => $ver }
+$builder was not found in configure_requires! Adding it now
+automatically as: configure_requires => { $builder => $ver }
 EOM
-    $self->_add_prereq('configure_requires', 'Module::Build', $ver);
+    $self->_add_prereq('configure_requires', $builder, $ver);
   }
 
   # if we're in author mode, add inc::latest modules to

--- a/t/metadata.t
+++ b/t/metadata.t
@@ -2,7 +2,7 @@
 
 use strict;
 use lib 't/lib';
-use MBTest tests => 53;
+use MBTest tests => 55;
 
 blib_load('Module::Build');
 blib_load('Module::Build::ConfigData');
@@ -97,6 +97,22 @@ my $mb = Module::Build->new_from_context;
 
   # exists() doesn't seem to work here
   is_deeply $node->{configure_requires}, $mb_prereq, 'Add M::B to configure_requires';
+
+
+  # test that subclass name is added to prereq
+  @Module::Build::MySubclass::ISA = 'Module::Build';
+  $Module::Build::MySubclass::VERSION = 0.01;
+  bless $mb, 'Module::Build::MySubclass';
+
+  my $output = stdout_stderr_of( sub {
+    $node = $mb->get_metadata( auto => 1 );
+  });
+  like( $output, qr/Module::Build::MySubclass was not found in configure_requires/,
+    "saw warning about subclass not in configure_requires"
+  );
+  $mb_prereq->{'Module::Build::MySubclass'} = 0.01;
+  is_deeply $node->{configure_requires}, $mb_prereq, 'Add M::B to configure_requires';
+
 }
 
 $dist->clean;


### PR DESCRIPTION
When subclassing Module::Build it would be useful if that subclass was automatically added to the configure_requires hash, rather than the base class (Module::Build). I have released several subclasses to CPAN lately (Alien::Base::ModuleBuild and Module::Build::CleanInstall) so this would be much appreciated. 
