### PR TITLE
Added test_requires.

### DIFF
--- a/lib/Module/Build/API.pod
+++ b/lib/Module/Build/API.pod
@@ -175,6 +175,15 @@ See L</auto_configure_requires> for details.
 See the documentation for L<Module::Build::Authoring/"PREREQUISITES">
 for the details of how requirements can be specified.
 
+=item test_requires
+
+[version 0.4004]
+
+Modules listed in this section must be installed before testing the distribution.
+
+See the documentation for L<Module::Build::Authoring/"PREREQUISITES">
+for the details of how requirements can be specified.
+
 =item create_packlist
 
 [version 0.28]
@@ -1753,7 +1762,7 @@ Examples:
 
 Returns a reference to a hash describing all prerequisites.  The keys of the
 hash will be the various prerequisite types ('requires', 'build_requires',
-'configure_requires', 'recommends', or 'conflicts') and the values will be
+'test_requires', 'configure_requires', 'recommends', or 'conflicts') and the values will be
 references to hashes of module names and version numbers.  Only prerequisites
 types that are defined will be included.  The C<prereq_data> action is just a
 thin wrapper around the C<prereq_data()> method and dumps the hash as a string

--- a/lib/Module/Build/Authoring.pod
+++ b/lib/Module/Build/Authoring.pod
@@ -183,6 +183,10 @@ ways to use this distribution without having them installed.  You
 might also think of this as "can use" or "is aware of" or "changes
 behavior in the presence of".
 
+=item test_requires
+
+Items that are necessary for testing.
+
 =item conflicts
 
 Items that can cause problems with this distribution when installed.

--- a/lib/Module/Build/Base.pm
+++ b/lib/Module/Build/Base.pm
@@ -942,7 +942,7 @@ __PACKAGE__->add_property(
 }
 
 {
-  my @prereq_action_types = qw(requires build_requires conflicts recommends);
+  my @prereq_action_types = qw(requires build_requires test_requires conflicts recommends);
   foreach my $type (@prereq_action_types) {
     __PACKAGE__->add_property($type => {});
   }
@@ -1915,6 +1915,7 @@ sub create_mymeta {
     # XXX refactor this mapping somewhere
     $mymeta->{prereqs}{runtime}{requires} = $prereqs->{requires};
     $mymeta->{prereqs}{build}{requires} = $prereqs->{build_requires};
+    $mymeta->{prereqs}{test}{requires} = $prereqs->{test_requires};
     $mymeta->{prereqs}{runtime}{recommends} = $prereqs->{recommends};
     $mymeta->{prereqs}{runtime}{conflicts} = $prereqs->{conflicts};
     # delete empty entries

--- a/t/metadata.t
+++ b/t/metadata.t
@@ -2,7 +2,7 @@
 
 use strict;
 use lib 't/lib';
-use MBTest tests => 53;
+use MBTest tests => 54;
 
 blib_load('Module::Build');
 blib_load('Module::Build::ConfigData');
@@ -15,6 +15,9 @@ my %metadata =
    dist_version  => '3.14159265',
    dist_author   => [ 'Simple Simon <ss\@somewhere.priv>' ],
    dist_abstract => 'Something interesting',
+   test_requires => {
+       'Test::More' => 0.98,
+   },
    license       => 'perl',
    meta_add => {
 		keywords  => [qw(super duper something)],
@@ -80,6 +83,9 @@ my $mb = Module::Build->new_from_context;
   is_deeply $node->{author}, $metadata{dist_author};
   is $node->{license}, $metadata{license};
   is_deeply $node->{configure_requires}, $mb_config_req, 'Add M::B to configure_requires';
+  is_deeply $node->{test_requires}, {
+      'Test::More' => '0.98',
+  }, 'Test::More was required by ->new';
   like $node->{generated_by}, qr{Module::Build};
   ok defined( $node->{'meta-spec'}{version} ),
       "'meta-spec' -> 'version' field present in META.yml";


### PR DESCRIPTION
I hope M::B to support test_requires option.
Because, today, cpanm supports test_requires feature.
cpanm does not install modules listed in test_requires, if the command executed with `--notest` option.
