### PR TITLE
Add $meta{prereqs}{test} to MYMETA.json and META.json

### DIFF
--- a/lib/Module/Build/Base.pm
+++ b/lib/Module/Build/Base.pm
@@ -1912,29 +1912,7 @@ sub create_mymeta {
   # if we have metadata, just update it
   if ( defined $mymeta ) {
     my $prereqs = $self->_normalize_prereqs;
-    # XXX refactor this mapping somewhere
-    $mymeta->{prereqs}{runtime}{requires} = $prereqs->{requires};
-    $mymeta->{prereqs}{build}{requires} = $prereqs->{build_requires};
-    $mymeta->{prereqs}{test}{requires} = $prereqs->{test_requires};
-    $mymeta->{prereqs}{runtime}{recommends} = $prereqs->{recommends};
-    $mymeta->{prereqs}{runtime}{conflicts} = $prereqs->{conflicts};
-    # delete empty entries
-    for my $phase ( keys %{$mymeta->{prereqs}} ) {
-      if ( ref $mymeta->{prereqs}{$phase} eq 'HASH' ) {
-        for my $type ( keys %{$mymeta->{prereqs}{$phase}} ) {
-          if ( ! defined $mymeta->{prereqs}{$phase}{$type}
-            || ! keys %{$mymeta->{prereqs}{$phase}{$type}}
-          ) {
-            delete $mymeta->{prereqs}{$phase}{$type};
-          }
-        }
-      }
-      if ( ! defined $mymeta->{prereqs}{$phase}
-        || ! keys %{$mymeta->{prereqs}{$phase}}
-      ) {
-        delete $mymeta->{prereqs}{$phase};
-      }
-    }
+    $self->_merge_meta_prereqs($mymeta, $prereqs);
     $mymeta->{dynamic_config} = 0;
     $mymeta->{generated_by} = "Module::Build version $Module::Build::VERSION";
     eval { $meta_obj = CPAN::Meta->new( $mymeta, { lazy_validation => 1 } ) }
@@ -1952,6 +1930,35 @@ sub create_mymeta {
     unless @created;
 
   return 1;
+}
+
+sub _merge_meta_prereqs {
+    my ($self, $meta, $prereqs) = @_;
+
+    $meta->{prereqs}{runtime}{requires} = $prereqs->{requires};
+    $meta->{prereqs}{build}{requires} = $prereqs->{build_requires};
+    $meta->{prereqs}{test}{requires} = $prereqs->{test_requires};
+    $meta->{prereqs}{runtime}{recommends} = $prereqs->{recommends};
+    $meta->{prereqs}{runtime}{conflicts} = $prereqs->{conflicts};
+
+    # delete empty entries
+    for my $phase ( keys %{$meta->{prereqs}} ) {
+      if ( ref $meta->{prereqs}{$phase} eq 'HASH' ) {
+        for my $type ( keys %{$meta->{prereqs}{$phase}} ) {
+          if ( ! defined $meta->{prereqs}{$phase}{$type}
+            || ! keys %{$meta->{prereqs}{$phase}{$type}}
+          ) {
+            delete $meta->{prereqs}{$phase}{$type};
+          }
+        }
+      }
+      if ( ! defined $meta->{prereqs}{$phase}
+        || ! keys %{$meta->{prereqs}{$phase}}
+      ) {
+        delete $meta->{prereqs}{$phase};
+      }
+    }
+    $meta;
 }
 
 sub create_build_script {
@@ -4571,6 +4578,12 @@ sub _get_meta_object {
     );
     $data->{dynamic_config} = $args{dynamic} if defined $args{dynamic};
     $meta = CPAN::Meta->create( $data );
+    # XXX get_metadata create spec 1.4 struct. needs to version up
+    my $meta2 = $meta->as_struct({version => "2"}); 
+    delete $meta2->{'x_'.$_} for @{$self->prereq_action_types}; 
+    my $prereqs = $self->_normalize_prereqs;
+    $self->_merge_meta_prereqs($meta2, $prereqs);
+    $meta = CPAN::Meta->create( $meta2 );
   };
   if ($@ && ! $args{quiet}) {
     $self->log_warn(

--- a/t/test_reqs.t
+++ b/t/test_reqs.t
@@ -1,0 +1,53 @@
+#!/usr/bin/perl -w
+
+use strict;
+use lib 't/lib';
+use MBTest;
+use CPAN::Meta 2.110420;
+use CPAN::Meta::YAML;
+use Parse::CPAN::Meta 1.4401;
+plan tests => 4;
+
+blib_load('Module::Build');
+
+my $tmp = MBTest->tmpdir;
+
+use DistGen;
+my $dist = DistGen->new( dir => $tmp );
+$dist->change_file('Build.PL', <<"---");
+use strict;
+use Module::Build;
+
+my \$builder = Module::Build->new(
+  module_name         => '$dist->{name}',
+  license             => 'perl',
+  requires            => {
+    'File::Spec' => 0,
+  },
+  test_requires       => {
+    'Test::More' => 0,
+  }
+);
+
+\$builder->create_build_script();
+---
+$dist->regen;
+$dist->chdir_in;
+$dist->run_build_pl;
+my $output = stdout_stderr_of sub { $dist->run_build('distmeta') };
+
+for my $file ( qw/MYMETA META/ ) {
+    my $meta = Parse::CPAN::Meta->load_file($file.".json");
+    is_deeply($meta->{prereqs}->{runtime},{
+        requires => {
+            'File::Spec' => '0',
+        }
+    }, "runtime prereqs in $file");
+    is_deeply($meta->{prereqs}->{test},{
+        requires => {
+            'Test::More' => '0',
+        }
+    }, "test prereqs in $file");
+}
+
+


### PR DESCRIPTION
Module::Build 0.4004 supports test_configure. But MYMETA.json and META.json (generated by `perl ./Build.PL` and `./Build distmeta`) does not have $meta{prereqs}{test}. They have x_test_requires.

After ./Build distmata, When I run `perl ./Build.PL` again. I got $meta{prereqs}{test} in MYMETA.json. 
It is enough for installing prereqs modules, but confusing. I want to get $meta{prereqs}{test} in first `perl ./Build.PL`

This patch upgrades a metadata that created by get_metadata() to spec-2 before write meta files.
