### PR TITLE
Fix links between modules in HTML docs output

### DIFF
--- a/lib/Module/Build/Base.pm
+++ b/lib/Module/Build/Base.pm
@@ -3429,7 +3429,7 @@ sub htmlify_pods {
       } or $self->log_warn("[$htmltool] pod2html (" .
         join(", ", map { "q{$_} => q{$opts{$_}}" } (keys %opts)) . ") failed: $@");
     } else {
-      my $path2root = join( '/', ('..') x (@rootdirs+@dirs) );
+      my $path2root = join( '/', ('..') x (@dirs) );
       my $fh = IO::File->new($infile) or die "Can't read $infile: $!";
       my $abstract = Module::Build::PodParser->new(fh => $fh)->get_abstract();
 


### PR DESCRIPTION
The relative path to the root directory was wrong.

Probably the code handling the ActiveState distribution case also needs
the same fix, but I can't test it and hence haven't included it in this
fix.

Signed-off-by: Michael Wild themiwi@users.sourceforge.net
