### PR TITLE
conditionally use deprecate.pm: Module-Build to leave core

### DIFF
--- a/lib/Module/Build.pm
+++ b/lib/Module/Build.pm
@@ -7,6 +7,7 @@ package Module::Build;
 # done in Module::Build::Base.
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use File::Spec ();
 use File::Path ();
 use File::Basename ();

--- a/lib/Module/Build/Base.pm
+++ b/lib/Module/Build/Base.pm
@@ -3,6 +3,7 @@
 package Module::Build::Base;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 use warnings;
 

--- a/lib/Module/Build/Compat.pm
+++ b/lib/Module/Build/Compat.pm
@@ -1,6 +1,7 @@
 package Module::Build::Compat;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 

--- a/lib/Module/Build/Config.pm
+++ b/lib/Module/Build/Config.pm
@@ -1,6 +1,7 @@
 package Module::Build::Config;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/Cookbook.pm
+++ b/lib/Module/Build/Cookbook.pm
@@ -1,5 +1,6 @@
 package Module::Build::Cookbook;
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 

--- a/lib/Module/Build/Dumper.pm
+++ b/lib/Module/Build/Dumper.pm
@@ -1,5 +1,6 @@
 package Module::Build::Dumper;
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 

--- a/lib/Module/Build/ModuleInfo.pm
+++ b/lib/Module/Build/ModuleInfo.pm
@@ -3,6 +3,7 @@
 package Module::Build::ModuleInfo;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/Notes.pm
+++ b/lib/Module/Build/Notes.pm
@@ -3,6 +3,7 @@ package Module::Build::Notes;
 # A class for persistent hashes
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/PPMMaker.pm
+++ b/lib/Module/Build/PPMMaker.pm
@@ -1,6 +1,7 @@
 package Module::Build::PPMMaker;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use Config;
 use vars qw($VERSION);
 use IO::File;

--- a/lib/Module/Build/Platform/Default.pm
+++ b/lib/Module/Build/Platform/Default.pm
@@ -1,6 +1,7 @@
 package Module::Build::Platform::Default;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/Platform/MacOS.pm
+++ b/lib/Module/Build/Platform/MacOS.pm
@@ -1,6 +1,7 @@
 package Module::Build::Platform::MacOS;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/Platform/Unix.pm
+++ b/lib/Module/Build/Platform/Unix.pm
@@ -1,6 +1,7 @@
 package Module::Build::Platform::Unix;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/Platform/VMS.pm
+++ b/lib/Module/Build/Platform/VMS.pm
@@ -1,6 +1,7 @@
 package Module::Build::Platform::VMS;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/Platform/VOS.pm
+++ b/lib/Module/Build/Platform/VOS.pm
@@ -1,6 +1,7 @@
 package Module::Build::Platform::VOS;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/Platform/Windows.pm
+++ b/lib/Module/Build/Platform/Windows.pm
@@ -1,6 +1,7 @@
 package Module::Build::Platform::Windows;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/Platform/aix.pm
+++ b/lib/Module/Build/Platform/aix.pm
@@ -1,6 +1,7 @@
 package Module::Build::Platform::aix;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/Platform/cygwin.pm
+++ b/lib/Module/Build/Platform/cygwin.pm
@@ -1,6 +1,7 @@
 package Module::Build::Platform::cygwin;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/Platform/darwin.pm
+++ b/lib/Module/Build/Platform/darwin.pm
@@ -1,6 +1,7 @@
 package Module::Build::Platform::darwin;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/Platform/os2.pm
+++ b/lib/Module/Build/Platform/os2.pm
@@ -1,6 +1,7 @@
 package Module::Build::Platform::os2;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/PodParser.pm
+++ b/lib/Module/Build/PodParser.pm
@@ -1,6 +1,7 @@
 package Module::Build::PodParser;
 
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/Module/Build/Version.pm
+++ b/lib/Module/Build/Version.pm
@@ -1,5 +1,6 @@
 package Module::Build::Version;
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.87'; ### XXX sync with version of version.pm below
 

--- a/lib/Module/Build/YAML.pm
+++ b/lib/Module/Build/YAML.pm
@@ -1,5 +1,6 @@
 package Module::Build::YAML;
 use strict;
+use if $] > 5.018, 'deprecate';
 use CPAN::Meta::YAML 0.002 ();
 our @ISA = qw(CPAN::Meta::YAML);
 our $VERSION  = '1.41';

--- a/lib/inc/latest.pm
+++ b/lib/inc/latest.pm
@@ -1,5 +1,6 @@
 package inc::latest;
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;

--- a/lib/inc/latest/private.pm
+++ b/lib/inc/latest/private.pm
@@ -1,5 +1,6 @@
 package inc::latest::private;
 use strict;
+use if $] > 5.018, 'deprecate';
 use vars qw($VERSION);
 $VERSION = '0.4005';
 $VERSION = eval $VERSION;


### PR DESCRIPTION
Note that this affects inc::latest and inc::latest::private as
well.  If these should be staying in core then we need to:

a) say so
b) split them into their own distribution.
