### PR TITLE
Extract install path logic

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -41,6 +41,7 @@ my $build = ModuleBuildBuilder->new(
     'File::Spec'            => ($^O eq 'MSWin32' ? 3.30 : '0.82'), # rel2abs()
     'ExtUtils::CBuilder'    => 0.27, # major platform fixes
     'ExtUtils::Install'     => 0,
+    'ExtUtils::InstallPaths'=> 0.003,
     'ExtUtils::Manifest'    => 0,
     'ExtUtils::Mkbootstrap' => 0,
     'ExtUtils::ParseXS'     => 2.21, # various bug fixes


### PR DESCRIPTION
This branch splits out ExtUtils::Config and ExtUtils::InstallPaths from Module::Build. That way, it enables other modules to use these pieces of logic.

**This should probably not be applied until Module::Build leaves core**.
