### PR TITLE
fix check_compiler when cross-compiling

### DIFF
--- a/t/lib/MBTest.pm
+++ b/t/lib/MBTest.pm
@@ -197,6 +197,7 @@ sub find_in_path {
 }
 
 sub check_compiler {
+  return 0 if $ENV{PERL_CORE} && $Config{'usecrosscompile'};
   return (1,1) if $ENV{PERL_CORE};
 
   local $SIG{__WARN__} = sub {};


### PR DESCRIPTION
the compiler is not installed on target when cross-compiling
