### PR TITLE
M::B::Unix::_detildefy: Protect against platforms without getpw{nam,uid}

### DIFF
--- a/lib/Module/Build/Platform/Unix.pm
+++ b/lib/Module/Build/Platform/Unix.pm
@@ -43,8 +43,8 @@ sub _detildefy {
   my ($self, $value) = @_;
   $value =~ s[^~([^/]+)?(?=/|$)]   # tilde with optional username
     [$1 ?
-     ((getpwnam $1)[7] || "~$1") :
-     ($ENV{HOME} || (getpwuid $>)[7])
+     (eval{(getpwnam $1)[7]} || "~$1") :
+     ($ENV{HOME} || eval{(getpwuid $>)[7]} || glob("~"))
     ]ex;
   return $value;
 }


### PR DESCRIPTION
Unfortunately there is no %Config key to check, so we have to
eval {} the calls; We also make the getpwuid case default to glob("~").

This is really for Android; it looks like older versions of the OS didn't have the functions.
