### PR TITLE
Set AUTH tests when running disttest

### DIFF
--- a/lib/Module/Build/Base.pm
+++ b/lib/Module/Build/Base.pm
@@ -4069,6 +4069,8 @@ sub ACTION_disttest {
           or die "Error executing 'Build.PL' in dist directory: $!";
         $self->run_perl_script($self->build_script)
           or die "Error executing $self->build_script in dist directory: $!";
+
+        $ENV{RELEASE_TESTING} = 1;
         $self->run_perl_script($self->build_script, [], ['test'])
           or die "Error executing 'Build test' in dist directory";
       });


### PR DESCRIPTION
Set author tests when running `disttest`
Why this specific env var: it is the one used by Module-Starter - trying to be coherent.
