### PR TITLE
Stop using version->normal(); prefer stringify()

### DIFF
--- a/lib/Module/Build/Base.pm
+++ b/lib/Module/Build/Base.pm
@@ -4582,7 +4582,7 @@ sub normalize_version {
     # take as is without modification
   }
   elsif ( ref $version eq 'version') { # version objects
-    $version = $version->is_qv ? $version->normal : $version->stringify;
+    $version = $version->stringify;
   }
   elsif ( $version =~ /^[^v][^.]*\.[^.]+\./ ) { # no leading v, multiple dots
     # normalize string tuples without "v": "1.2.3" -> "v1.2.3"


### PR DESCRIPTION
In order to fix a bug in version:

  https://rt.cpan.org/Ticket/Display.html?id=93340

the behavior of normal() on dotted-decimal alpha versions,
e.g. "v1.2.3_1", was changed to emit a warning that this was
a lossy method and render it as "v1.2.3.1".

Using stringify() instead will ensure that the original
representation is returned (with the underscore), so that M::B's
own heuristic to determine whether the release_status is unstable
to continue working.  Alternatively, keeping the version object,
instead of jamming it into a string, you could use the is_alpha()
object method instead.