### PR TITLE
PodParser now respects =encoding directives

### DIFF
--- a/lib/Module/Build/PodParser.pm
+++ b/lib/Module/Build/PodParser.pm
@@ -25,7 +25,7 @@ sub parse_from_filehandle {
 
   local $_;
   while (<$fh>) {
-    next unless /^ =encoding \s+ (\S*)/ix;
+    next unless /^ =encoding \s+ (\S+)/ix;
     binmode $fh, ":encoding($1)";
     last;
   }

--- a/lib/Module/Build/PodParser.pm
+++ b/lib/Module/Build/PodParser.pm
@@ -25,6 +25,13 @@ sub parse_from_filehandle {
 
   local $_;
   while (<$fh>) {
+    next unless /=encoding \s+ (.*)/ix;
+    binmode $fh, ":encoding($1)";
+    last;
+  }
+  seek $fh, 0, 0;
+
+  while (<$fh>) {
     next unless /^=(?!cut)/ .. /^=cut/;  # in POD
     # Accept Name - abstract or C<Name> - abstract
     last if ($self->{abstract}) = /^ (?: [a-z_0-9:]+ | [BCIF] < [a-z_0-9:]+ > ) \s+ - \s+ (.*\S) /ix;

--- a/lib/Module/Build/PodParser.pm
+++ b/lib/Module/Build/PodParser.pm
@@ -25,7 +25,7 @@ sub parse_from_filehandle {
 
   local $_;
   while (<$fh>) {
-    next unless /=encoding \s+ (.*)/ix;
+    next unless /^ =encoding \s+ (.*)/ix;
     binmode $fh, ":encoding($1)";
     last;
   }

--- a/lib/Module/Build/PodParser.pm
+++ b/lib/Module/Build/PodParser.pm
@@ -25,7 +25,7 @@ sub parse_from_filehandle {
 
   local $_;
   while (<$fh>) {
-    next unless /^ =encoding \s+ (.*)/ix;
+    next unless /^ =encoding \s+ (\S*)/ix;
     binmode $fh, ":encoding($1)";
     last;
   }


### PR DESCRIPTION
When deriving authors or abstract from pod, if encoding is ignored the
related META files will then be incorrect.

This implementation makes reading the pod two pass, first to find an
=encoding directive if it exists and if so set the binmode, then seeks
back to the top to continue parsing as usual.

To support this I have also moved away from testing with a tied class,
which was then mocking out everything that was attempting to be tested.
It now simply uses open to a string.
