### PR TITLE
Perl 5.6

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -45,7 +45,7 @@ my $build = ModuleBuildBuilder->new(
   # KEEP 'requires' as low as possible and target Build/test/install
   # Requirements for authors should be implemented as optional features
   requires    => {
-    'perl'                  => '5.008000',
+    'perl'                  => '5.006001',
     'Data::Dumper'          => 0,
     'File::Basename'        => 0,
     'File::Compare'         => 0,

--- a/lib/Module/Build/Base.pm
+++ b/lib/Module/Build/Base.pm
@@ -1900,7 +1900,7 @@ sub create_mymeta {
   }
 
   # Try loading META.json or META.yml
-  if ( $self->try_require("CPAN::Meta", "2.110420") ) {
+  if ( $self->try_require("CPAN::Meta", "2.142060") ) {
     for my $file ( @metafiles ) {
       next unless -f $file;
       $meta_obj = eval { CPAN::Meta->load_file($file, { lazy_validation => 0 }) };
@@ -4546,7 +4546,7 @@ sub _write_meta_files {
 sub _get_meta_object {
   my $self = shift;
   my %args = @_;
-  return unless $self->try_require("CPAN::Meta", "2.110420");
+  return unless $self->try_require("CPAN::Meta", "2.142060");
 
   my $meta;
   eval {

--- a/t/extend.t
+++ b/t/extend.t
@@ -178,7 +178,8 @@ print "Hello, World!\n";
   is $mb->bar, 'yow';
 }
 
-{
+SKIP: {
+  skip 'Need CPAN::Meta 2.142060 for Meta support', 4 if not eval { require CPAN::Meta; CPAN::Meta->VERSION(2.142060) };
   # Test the meta_add and meta_merge stuff
   ok my $mb = Module::Build->new(
 				  module_name => $dist->name,

--- a/t/lib/MBTest.pm
+++ b/t/lib/MBTest.pm
@@ -144,6 +144,7 @@ sub import {
 # Setup a temp directory
 sub tmpdir {
   my ($self, @args) = @_;
+  local $ENV{TMPDIR} = $ENV{TMPDIR} || '';
   my $dir = $ENV{PERL_CORE} ? MBTest->original_cwd : File::Spec->tmpdir;
   return File::Temp::tempdir('MB-XXXXXXXX', CLEANUP => 1, DIR => $dir, @args);
 }

--- a/t/manifypods_with_utf8.t
+++ b/t/manifypods_with_utf8.t
@@ -7,13 +7,8 @@ use lib 't/lib';
 blib_load('Module::Build');
 blib_load('Module::Build::ConfigData');
 
-SKIP: {
-   unless ( Module::Build::ConfigData->feature('manpage_support') ) {
-     skip 'manpage_support feature is not enabled';
-   }
-}
-
-use MBTest tests => 2;
+use MBTest;
+plan($] > 5.008 ? (tests => 2) : skip_all => 'UTF-8 manpages require perl 5.8.1');
 use File::Spec::Functions qw( catdir );
 
 use Cwd ();

--- a/t/metadata.t
+++ b/t/metadata.t
@@ -2,7 +2,14 @@
 
 use strict;
 use lib 't/lib';
-use MBTest tests => 14;
+use MBTest;
+
+if (eval { require CPAN::Meta; CPAN::Meta->VERSION(2.142060) }) {
+	plan(tests => 14);
+}
+else {
+	plan(skip_all => 'No or old CPAN::Meta');
+}
 
 blib_load('Module::Build');
 blib_load('Module::Build::ConfigData');

--- a/t/metadata2.t
+++ b/t/metadata2.t
@@ -2,7 +2,14 @@
 
 use strict;
 use lib 't/lib';
-use MBTest tests => 18;
+use MBTest;
+
+if (eval { require CPAN::Meta; CPAN::Meta->VERSION(2.142060) }) {
+	plan(tests => 18);
+}
+else {
+	plan(skip_all => 'No or old CPAN::Meta');
+}
 
 blib_load('Module::Build');
 blib_load('Module::Build::ConfigData');

--- a/t/mymeta.t
+++ b/t/mymeta.t
@@ -3,10 +3,15 @@
 use strict;
 use lib 't/lib';
 use MBTest;
-use CPAN::Meta 2.110420;
-use CPAN::Meta::YAML;
-use Parse::CPAN::Meta 1.4401;
-plan tests => 41;
+
+if (eval { require CPAN::Meta; CPAN::Meta->VERSION(2.142060) }) {
+	plan(tests => 41);
+	require CPAN::Meta::YAML;
+	require Parse::CPAN::Meta;
+}
+else {
+	plan(skip_all => 'No or old CPAN::Meta');
+}
 
 blib_load('Module::Build');
 

--- a/t/properties/license.t
+++ b/t/properties/license.t
@@ -3,7 +3,14 @@ use lib 't/lib';
 use MBTest;
 use DistGen;
 
-plan 'no_plan';
+if (eval { require CPAN::Meta; CPAN::Meta->VERSION(2.142060) }) {
+	plan('no_plan');
+	require CPAN::Meta::YAML;
+	require Parse::CPAN::Meta;
+}
+else {
+	plan(skip_all => 'No or old CPAN::Meta');
+}
 
 # Ensure any Module::Build modules are loaded from correct directory
 blib_load('Module::Build');

--- a/t/runthrough.t
+++ b/t/runthrough.t
@@ -124,11 +124,14 @@ ok grep {$_ eq 'save_out'     } $mb->cleanup;
   # else it could get into the tarball
   ok ! -e File::Spec->catdir('Simple-0.01', 'blib');
 
-  # Make sure all of the above was done by the new version of Module::Build
-  open(my $fh, '<', File::Spec->catfile($dist->dirname, 'META.yml'));
-  my $contents = do {local $/; <$fh>};
-  $contents =~ /Module::Build version ([0-9_.]+)/m;
-  cmp_ok $1, '==', $mb->VERSION, "Check version used to create META.yml: $1 == " . $mb->VERSION;
+  SKIP: {
+    skip 'CPAN::Meta 2.142060+ not installed', 1 if not eval { require CPAN::Meta; CPAN::Meta->VERSION(2.142060) };
+    # Make sure all of the above was done by the new version of Module::Build
+    open(my $fh, '<', File::Spec->catfile($dist->dirname, 'META.yml'));
+    my $contents = do {local $/; <$fh>};
+    $contents =~ /Module::Build version ([0-9_.]+)/m;
+    cmp_ok $1, '==', $mb->VERSION, "Check version used to create META.yml: $1 == " . $mb->VERSION;
+  }
 
   SKIP: {
     skip( "Archive::Tar 1.08+ not installed", 1 )

--- a/t/script_dist.t
+++ b/t/script_dist.t
@@ -73,7 +73,9 @@ my $result;
 stdout_stderr_of( sub { $result = $mb->dispatch('distmeta') } );
 ok $result;
 
-my $yml = CPAN::Meta::YAML->read_string(slurp('META.yml'))->[0];
-is_deeply($yml->{provides}, \%meta_provides);
+if (eval { require CPAN::Meta; CPAN::Meta->VERSION(2.142060); }) {
+	my $yml = CPAN::Meta::YAML->read_string(slurp('META.yml'))->[0];
+	is_deeply($yml->{provides}, \%meta_provides);
+}
 
 $dist->chdir_original if $dist->did_chdir;

--- a/t/test_reqs.t
+++ b/t/test_reqs.t
@@ -6,7 +6,16 @@ use MBTest;
 use CPAN::Meta 2.110420;
 use CPAN::Meta::YAML;
 use Parse::CPAN::Meta 1.4401;
-plan tests => 4;
+
+if (eval { require CPAN::Meta; CPAN::Meta->VERSION(2.142060) }) {
+	plan(tests => 4);
+	require CPAN::Meta::YAML;
+	require Parse::CPAN::Meta;
+}
+else {
+	plan(skip_all => 'No or old CPAN::Meta');
+}
+
 
 blib_load('Module::Build');
 


### PR DESCRIPTION
This should fix Module::Build on perl 5.6. First patch is a no-brainer, second patch I should perhaps instead depend on whatever version of File::Spec fixed that issue but whatever.

The third patch is a bit crude, but should allow Module::Build to install even when CPAN::Meta doesn't. I'm sure things could go wrong in such a case, but it's the best I can think of right now.

Feedback is welcome, will merge it into master otherwise.
