### PR TITLE
Change bugtracker to GitHub tracker

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -133,6 +133,9 @@ my $build = ModuleBuildBuilder->new(
       MailingList => 'mailto:module-build@perl.org',
       repository  => 'https://github.com/Perl-Toolchain-Gang/Module-Build',
       IRC         => 'irc://irc.perl.org/#toolchain',
+      bugtracker  => {
+                      web => 'https://github.com/Perl-Toolchain-Gang/Module-Build/issues',
+                     },
     }
   },
 );


### PR DESCRIPTION
Would people prefer to receive bug/feature reports on GitHub rather than RT?