### PR TITLE
read extra_linker_flags using its accessor

### DIFF
--- a/lib/Module/Build/Base.pm
+++ b/lib/Module/Build/Base.pm
@@ -5340,7 +5340,7 @@ sub link_c {
     module_name => $module_name,
     objects     => [$spec->{obj_file}, @$objects],
     lib_file    => $spec->{lib_file},
-    extra_linker_flags => $p->{extra_linker_flags} );
+    extra_linker_flags => $self->extra_linker_flags );
 
   return $spec->{lib_file};
 }


### PR DESCRIPTION
Module writers may like to override extra_linker_flags in order to add
new linker flags dynamically but the module was using the value stored
internally in $self->{properties}{extra_linker_flags}.

The same approach is already used for extra_compiler_flags.