### PR TITLE
Win32 installation of MB with gmake require SHELL env var to be set

### DIFF
--- a/lib/Module/Build/Compat.pm
+++ b/lib/Module/Build/Compat.pm
@@ -363,7 +363,9 @@ sub fake_makefile {
   my $unlink = $class->oneliner('1 while unlink $ARGV[0]', [], [$args{makefile}]);
   $unlink =~ s/\$/\$\$/g unless $class->is_vmsish;
 
-  my $maketext = ($^O eq 'os2' ? "SHELL = sh\n\n" : '');
+  my $maketext = ($^O eq 'os2' ? "SHELL = sh\n\n"
+                    : $^O eq 'MSWin32' && $Config{make} =~ /gmake/
+                    ? "SHELL = $ENV{COMSPEC}\n\n" : '');
 
   $maketext .= <<"EOF";
 all : force_do_it


### PR DESCRIPTION
see
https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/commit/ae56bdd74d532c6505b5a0467d5679b30e490908
for rational

fixes

C:\sources\Module-Build>gmake install
"C:/Program Files/Git/bin/sh.exe": rem: command not found
Makefile:14: recipe for target 'force_do_it' failed
gmake: *** [force_do_it] Error 127

C:\sources\Module-Build>