### PR TITLE
various wrong tests (cperl)

### DIFF
--- a/t/compat.t
+++ b/t/compat.t
@@ -239,7 +239,7 @@ ok $mb, "Module::Build->new_from_context";
     );
 
     require ExtUtils::Install;
-    skip "Needs ExtUtils::Install 1.32 or later", 2 * @cases
+    skip "Needs ExtUtils::Install 1.32 or later", int(2 * @cases)
       if ExtUtils::Install->VERSION < 1.32;
 
     for my $c (@cases) {
@@ -486,7 +486,7 @@ sub test_makefile_pl_files {
   my $expected = shift;
 
   SKIP: {
-    skip 1, 'Makefile.PL not found' unless -e 'Makefile.PL';
+    skip 'Makefile.PL not found', 1 unless -e 'Makefile.PL';
     my $args = extract_writemakefile_args() || {};
     is_deeply $args->{PL_FILES}, $expected,
       "Makefile.PL has correct PL_FILES line";
@@ -496,7 +496,7 @@ sub test_makefile_pl_files {
 sub test_makefile_pl_requires_perl {
   my $perl_version = shift || q{};
   SKIP: {
-    skip 1, 'Makefile.PL not found' unless -e 'Makefile.PL';
+    skip 'Makefile.PL not found', 1 unless -e 'Makefile.PL';
     my $file_contents = slurp 'Makefile.PL';
     my $found_requires = $file_contents =~ m{^require $perl_version;}ms;
     if (length $perl_version) {
@@ -537,7 +537,7 @@ sub find_params_in_makefile {
 
 sub extract_writemakefile_args {
   SKIP: {
-    skip 1, 'Makefile.PL not found' unless -e 'Makefile.PL';
+    skip 'Makefile.PL not found', 1 unless -e 'Makefile.PL';
     my $file_contents = slurp 'Makefile.PL';
     my ($args) = $file_contents =~ m{^WriteMakefile\n\((.*)\).*;}ms;
     ok $args, "Found WriteMakefile arguments"

--- a/t/manifypods_with_utf8.t
+++ b/t/manifypods_with_utf8.t
@@ -8,7 +8,7 @@ blib_load('Module::Build');
 blib_load('Module::Build::ConfigData');
 
 use MBTest;
-plan($] > 5.008 ? (tests => 2) : skip_all => 'UTF-8 manpages require perl 5.8.1');
+plan ($] > 5.008 ? (tests => 2) : (skip_all => 'UTF-8 manpages require perl 5.8.1'));
 use File::Spec::Functions qw( catdir );
 
 use Cwd ();


### PR DESCRIPTION
t/compat.t: fix wrong skip

    with cperl wrong skip types are fatal.
    1. type the skip count to int
    2. swap int $count with str $why

fix wrong plan:

    cperl has stricter signature checks:
    t/manifypods_with_utf8.t ....... Too many arguments for subroutine Test::Builder::plan. Want: 1-3, but got: 4 at /usr/local/lib/cperl/5.24.0/darwin@0a96cf3/Test/More.pm line 167.
