### PR TITLE
make_tarball: workaround for broken tar on Darwin

### DIFF
--- a/lib/Module/Build/Base.pm
+++ b/lib/Module/Build/Base.pm
@@ -4935,6 +4935,14 @@ sub make_tarball {
 
   if ($self->{args}{tar}) {
     my $tar_flags = $self->verbose ? 'cvf' : 'cf';
+
+    # See ExtUtils::MM_Darwin
+    # 10.4 wants COPY_EXTENDED_ATTRIBUTES_DISABLE.
+    # 10.5 wants COPYFILE_DISABLE.
+    # So just set both.
+    local $ENV{COPY_EXTENDED_ATTRIBUTES_DISABLE} = 1 if $^O eq 'darwin';
+    local $ENV{COPYFILE_DISABLE}                 = 1 if $^O eq 'darwin';
+
     $self->do_system($self->split_like_shell($self->{args}{tar}), $tar_flags, "$file.tar", $dir);
     $self->do_system($self->split_like_shell($self->{args}{gzip}), "$file.tar") if $self->{args}{gzip};
   } else {


### PR DESCRIPTION
On OS X /usr/bin/tar bundles extended attributes that trigger failures or warnings when the tarball is unpacked with GNU tar. See http://cpants.cpanauthors.org/kwalitee/no_pax_headers

So when the tarball is made using a tar executable on Darwin we take care of setting the appropriate environment variables to avoid the broken behaviour. The fix is the same [as in ExtUtils::MM_Darwin](https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/blob/master/lib/ExtUtils/MM_Darwin.pm#L38L43).

Cc: @haarg
