### PR TITLE
remove use deprecate

### DIFF
--- a/lib/Module/Build.pm
+++ b/lib/Module/Build.pm
@@ -1,7 +1,5 @@
 package Module::Build;
 
-use if $] >= 5.019, 'deprecate';
-
 # This module doesn't do much of anything itself, it inherits from the
 # modules that do the real work.  The only real thing it has to do is
 # figure out which OS-specific module to pull in.  Many of the


### PR DESCRIPTION
The deprecate module is meant for modules that are include in perl core
but will be removed in the future.  Now that Module::Build has been
removed, there is no need to continue using it, no matter the perl
version.