### PR TITLE
Improve pureperl-only support

### DIFF
--- a/lib/Module/Build/Base.pm
+++ b/lib/Module/Build/Base.pm
@@ -2865,6 +2865,7 @@ sub process_support_files {
   my $self = shift;
   my $p = $self->{properties};
   return unless $p->{c_source};
+  return if $self->pureperl_only && $self->allow_pureperl;
 
   my $files;
   if (ref($p->{c_source}) eq "ARRAY") {

--- a/lib/Module/Build/Base.pm
+++ b/lib/Module/Build/Base.pm
@@ -1517,7 +1517,11 @@ sub auto_require {
   # If set, we need ExtUtils::CBuilder (and a compiler)
   my $xs_files = $self->find_xs_files;
   if ( ! defined $p->{needs_compiler} ) {
-    $self->needs_compiler( keys %$xs_files || defined $self->c_source );
+    if ( $self->pureperl_only && $self->allow_pureperl ) {
+      $self->needs_compiler( 0 );
+    } else {
+      $self->needs_compiler( keys %$xs_files || defined $self->c_source );
+    }
   }
   if ($self->needs_compiler) {
     $self->_add_prereq('build_requires', 'ExtUtils::CBuilder', 0);


### PR DESCRIPTION
Address https://rt.cpan.org/Public/Bug/Display.html?id=119914

Currently even though the author set allow_pureperl true and users execute Build.PL with --pureperl-only, 
* Module::Build tries to compile c_sources
* Module::Build tries to require ExtUtils::CBuilder

I don't think these are necessary, so I fixed these.